### PR TITLE
Fix for spaces before percentage sign and space after symbol

### DIFF
--- a/trade_tariff_reference/documents/functions.py
+++ b/trade_tariff_reference/documents/functions.py
@@ -4,6 +4,7 @@ from __future__ import with_statement
 import os
 import re
 from contextlib import closing
+from unicodedata import normalize
 from zipfile import ZIP_DEFLATED, ZipFile
 
 
@@ -124,19 +125,19 @@ def remove_header_footer_xml(xml):
 
 
 def apply_value_format_to_document(document_xml_string):
-    document_xml_string = re.sub(
-        " ([0-9]{1,4}),([0-9]{1,4}) ", " \\1.\\2 ", document_xml_string, flags=re.MULTILINE
-    )
+    document_xml_string = normalize('NFKD', document_xml_string)
     document_xml_string = re.sub(
         "([0-9]{1,4}),([0-9]{1,4})/", "\\1.\\2/", document_xml_string, flags=re.MULTILINE
     )
     document_xml_string = re.sub(
-        " ([0-9]{1,4}),([0-9]{1,4})%", " \\1.\\2%", document_xml_string, flags=re.MULTILINE
+        "([0-9]{1,4}),([0-9]{1,4})(\\s?)%", "\\1.\\2%", document_xml_string, flags=re.MULTILINE
     )
     document_xml_string = re.sub(
-        " ([0-9]{1,4}),([0-9]{1,4})\\)", " \\1.\\2)", document_xml_string, flags=re.MULTILINE
+        "([0-9]{1,4})(\\s)%", "\\1%", document_xml_string, flags=re.MULTILINE
     )
-    document_xml_string = re.sub("([0-9]),([0-9])%", "\\1.\\2%", document_xml_string, flags=re.MULTILINE)
+    document_xml_string = re.sub(
+        "([0-9]{1,4}),([0-9]{1,4})\\)", "\\1.\\2)", document_xml_string, flags=re.MULTILINE
+    )
     document_xml_string = re.sub("([0-9]),([0-9]) kg", "\\1.\\2 kg", document_xml_string, flags=re.MULTILINE)
     document_xml_string = re.sub("([0-9]),([0-9]) Kg", "\\1.\\2 kg", document_xml_string, flags=re.MULTILINE)
     document_xml_string = re.sub("([0-9]),([0-9])kg", "\\1.\\2kg", document_xml_string, flags=re.MULTILINE)
@@ -173,7 +174,12 @@ def apply_value_format_to_document(document_xml_string):
     )
     document_xml_string = re.sub("±([0-9]{1,2}),([0-9]{1,3})", "±\\1.\\2", document_xml_string, flags=re.MULTILINE)
     document_xml_string = re.sub(
-        "€ ([0-9]{1,3}),([0-9]{1,3})", "€ \\1.\\2", document_xml_string, flags=re.MULTILINE
+        "€(\\s?)([0-9]{1,3})", "€\\2", document_xml_string, flags=re.MULTILINE
     )
-
+    document_xml_string = re.sub(
+        "€([0-9]{1,3}),([0-9]{1,3})", "€\\1.\\2", document_xml_string, flags=re.MULTILINE
+    )
+    document_xml_string = re.sub(
+        " ([0-9]{1,4}),([0-9]{1,4}) ", " \\1.\\2 ", document_xml_string, flags=re.MULTILINE
+    )
     return document_xml_string

--- a/trade_tariff_reference/documents/mfn/chapter.py
+++ b/trade_tariff_reference/documents/mfn/chapter.py
@@ -3,6 +3,7 @@ import logging
 import os
 import tempfile
 from distutils.dir_util import copy_tree
+from unicodedata import normalize
 
 from botocore.exceptions import EndpointConnectionError
 
@@ -175,6 +176,7 @@ class Chapter:
             chapter_log.log_document_history(remote_file_name)
 
     def write(self, document_xml):
+        document_xml = normalize('NFKD', document_xml)
         document_xml = f.apply_value_format_to_document(document_xml)
         ###########################################################################
         # WRITE document.xml

--- a/trade_tariff_reference/documents/tests/test_functions.py
+++ b/trade_tariff_reference/documents/tests/test_functions.py
@@ -164,7 +164,9 @@ def test_remove_header_footer_xml(value, expected_result):
         (' 12,5678%', ' 12.5678%'),
         (' 12,5678 )', ' 12.5678 )'),
         (' 12,5678)', ' 12.5678)'),
+        ('12,5678)', '12.5678)'),
         ('1,2%', '1.2%'),
+        ('70 %', '70%'),
         ('10,2%', '10.2%'),
         ('20,2 Kg', '20.2 kg'),
         ('30,2Kg', '30.2kg'),
@@ -196,11 +198,15 @@ def test_remove_header_footer_xml(value, expected_result):
         ('40,2 dB', '40.2 dB'),
         ('40,2 kvar', '40.2 kvar'),
         ('±40,2', '±40.2'),
-        ('€ 40,20', '€ 40.20'),
-
-
+        ('€ 40,20', '€40.20'),
+        ('€40,20', '€40.20'),
+        ('€40.20', '€40.20'),
+        ('€ 224', '€224'),
+        (
+            'Lithium metal of a purity by weight of 98,8 % or more (CAS RN 7439-93-2)',
+            'Lithium metal of a purity by weight of 98.8% or more (CAS RN 7439-93-2)',
+        ),
     ),
-
 )
 def test_apply_value_format_to_document(value, expected_result):
     assert functions.apply_value_format_to_document(value) == expected_result


### PR DESCRIPTION
Fixes for:
 - https://uktrade.atlassian.net/browse/TARIFFS-485
 - https://uktrade.atlassian.net/browse/TARIFFS-486
 - https://uktrade.atlassian.net/browse/TARIFFS-489